### PR TITLE
Habilitar opción "volumes"

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -102,6 +102,13 @@ exports.read = function (configFileName) {
 		mupJson.publishNetwork = mupJson.publishNetwork || (mupJson.containersConfig ? '0.0.0.0' : false);
 		mupJson.afterRunCommand = mupJson.afterRunCommand || '';
 
+		if (mupJson.volumes && mupJson.volumes.length) {
+			mupJson.volumes = ['/opt/backups:/backups'].concat(mupJson.volumes);
+		} else {
+			mupJson.volumes = ['/opt/backups:/backups'];
+		}
+		mupJson.volumes = mupJson.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '');
+		
 		return mupJson;
 	} else {
 		var message =

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -85,7 +85,7 @@ exports.deploy = function (bundlePath, env, config) {
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
 			afterRunCommand: config.afterRunCommand,
-			volumes: Object.keys(config.volumes).map(v => `${v}:${config.volumes[v]}`)
+			volumes: config.volumes
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -85,7 +85,7 @@ exports.deploy = function (bundlePath, env, config) {
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
 			afterRunCommand: config.afterRunCommand,
-			volumes: config.volumes
+			volumes: Object.keys(config.volumes).map(v => `${v}:${config.volumes[v]}`)
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -72,7 +72,7 @@ exports.deploy = function (bundlePath, env, config) {
 
 	copyEnvVars(taskList, env, appName);
 
-	taskList.copy('Initializing start script', {
+	taskList.copy('Initializing start script. Volumes var: ' + config.volumes + ', isArray: ' + Array.isArray(config.volumes) + " procesada: " + config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '\\'), {
 		src: path.resolve(TEMPLATES_DIR, 'start.sh'),
 		dest: '/opt/' + appName + '/config/start.sh',
 		vars: {
@@ -85,7 +85,7 @@ exports.deploy = function (bundlePath, env, config) {
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
 			afterRunCommand: config.afterRunCommand,
-			volumes: config.volumes
+			volumes: '' + config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '\\')
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -72,7 +72,7 @@ exports.deploy = function (bundlePath, env, config) {
 
 	copyEnvVars(taskList, env, appName);
 
-	taskList.copy('Initializing start script. Volumes var: ' + config.volumes + ', isArray: ' + Array.isArray(config.volumes) + " procesada: " + config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '\\'), {
+	taskList.copy('Initializing start script.', {
 		src: path.resolve(TEMPLATES_DIR, 'start.sh'),
 		dest: '/opt/' + appName + '/config/start.sh',
 		vars: {
@@ -85,7 +85,7 @@ exports.deploy = function (bundlePath, env, config) {
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
 			afterRunCommand: config.afterRunCommand,
-			volumes: '' + config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '\\')
+			volumes: config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '')
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -10,6 +10,8 @@ var TEMPLATES_DIR = path.resolve(__dirname, '../../templates/linux');
 exports.setup = function (config) {
 	var taskList = nodemiral.taskList('Setup (linux)');
 
+	console.log("config", config);
+
 	if (!config.containersConfig) {
 		taskList.executeScript('Installing Docker', {
 			script: path.resolve(SCRIPT_DIR, 'install-docker.sh')
@@ -22,7 +24,7 @@ exports.setup = function (config) {
 			appName: config.appName,
 			port: config.env && config.env.PORT,
 			host: ((config.env && config.env.ROOT_URL) || '').split('//').pop().replace(/\//g, ''),
-			containersConfig: !!config.containersConfig
+			containersConfig: !!config.containersConfig,
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -72,7 +72,7 @@ exports.deploy = function (bundlePath, env, config) {
 
 	copyEnvVars(taskList, env, appName);
 
-	taskList.copy('Initializing start script.', {
+	taskList.copy('Initializing start script', {
 		src: path.resolve(TEMPLATES_DIR, 'start.sh'),
 		dest: '/opt/' + appName + '/config/start.sh',
 		vars: {
@@ -85,7 +85,7 @@ exports.deploy = function (bundlePath, env, config) {
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
 			afterRunCommand: config.afterRunCommand,
-			volumes: config.volumes.reduce(function (v, n) {return '--volume=' + n + ' ' + v}, '')
+			volumes: config.volumes
 		}
 	});
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -10,8 +10,6 @@ var TEMPLATES_DIR = path.resolve(__dirname, '../../templates/linux');
 exports.setup = function (config) {
 	var taskList = nodemiral.taskList('Setup (linux)');
 
-	console.log("config", config);
-
 	if (!config.containersConfig) {
 		taskList.executeScript('Installing Docker', {
 			script: path.resolve(SCRIPT_DIR, 'install-docker.sh')
@@ -86,7 +84,8 @@ exports.deploy = function (bundlePath, env, config) {
 			noMail: config.noMail,
 			mailName: config.mailName,
 			publishNetwork: config.publishNetwork,
-			afterRunCommand: config.afterRunCommand
+			afterRunCommand: config.afterRunCommand,
+			volumes: config.volumes
 		}
 	});
 

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,6 +13,8 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
+echo ============== $VOLUMES
+
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
 

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,7 +13,7 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-echo ============== $VOLUMES > /tmp/testeandoLogs
+echo ============== $VOLUMES > /home/testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -27,11 +27,11 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
   if [ "$LINK_MAIL" == "1" ]; then
     docker run \
       -d \
-      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
+      --mount $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -42,11 +42,11 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
   else
     docker run \
       -d \
-      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
+      --mount $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \
@@ -58,11 +58,11 @@ else
   if [ "$LINK_MAIL" == "1" ]; then
     docker run \
       -d \
-      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
+      --mount $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -72,11 +72,11 @@ else
   else
     docker run \
       -d \
-      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
+      --mount $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,7 +13,7 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-echo ============== $VOLUMES
+echo ============== $VOLUMES > testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,7 +13,8 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-echo ============== $VOLUMES > testeandoLogs
+mkdir heyyou
+echo ============== $VOLUMES > heyyou/testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,7 +13,7 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-echo ============== $VOLUMES > /home/testeandoLogs
+echo $VOLUMES > /home/testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
@@ -31,7 +31,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --volume $VOLUMES \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -46,7 +46,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --volume $VOLUMES \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \
@@ -62,7 +62,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --volume $VOLUMES \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -76,7 +76,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --volume $VOLUMES \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -14,7 +14,6 @@ AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
 echo $VOLUMES
-return
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,8 +13,7 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-mkdir heyyou
-echo ============== $VOLUMES > heyyou/testeandoLogs
+echo ============== $VOLUMES > /tmp/testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -31,7 +31,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --mount $VOLUMES \
+      --volume $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -46,7 +46,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --mount $VOLUMES \
+      --volume $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \
@@ -62,7 +62,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --mount $VOLUMES \
+      --volume $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -76,7 +76,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      --mount $VOLUMES \
+      --volume $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -11,6 +11,7 @@ MAIL_NAME=<%= mailName %>
 PUBLISH_NETWORK=<%= publishNetwork ? publishNetwork : "127.0.0.1" %>
 DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
+VOLUMES="<%= volumes %>"
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
@@ -27,7 +28,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      <%= volumes %> \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -41,7 +42,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      <%= volumes %> \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \
@@ -56,7 +57,7 @@ else
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      <%= volumes %> \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -69,7 +70,7 @@ else
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      <%= volumes %> \
+      $VOLUMES \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -11,6 +11,10 @@ MAIL_NAME=<%= mailName %>
 PUBLISH_NETWORK=<%= publishNetwork ? publishNetwork : "127.0.0.1" %>
 DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
+VOLUMES=<%= volumes %>
+
+echo $VOLUMES
+return
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -28,6 +28,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
   if [ "$LINK_MAIL" == "1" ]; then
     docker run \
       -d \
+      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
@@ -42,6 +43,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
   else
     docker run \
       -d \
+      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
@@ -57,6 +59,7 @@ else
   if [ "$LINK_MAIL" == "1" ]; then
     docker run \
       -d \
+      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
@@ -70,6 +73,7 @@ else
   else
     docker run \
       -d \
+      -v $VOLUMES \
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -27,7 +27,6 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      --volume=/opt/backups:/backups \
       <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
@@ -42,7 +41,6 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      --volume=/opt/backups:/backups \
       <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
@@ -58,7 +56,6 @@ else
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      --volume=/opt/backups:/backups \
       <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
@@ -72,7 +69,6 @@ else
       --restart=always \
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
-      --volume=/opt/backups:/backups \
       <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -11,9 +11,6 @@ MAIL_NAME=<%= mailName %>
 PUBLISH_NETWORK=<%= publishNetwork ? publishNetwork : "127.0.0.1" %>
 DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
-VOLUMES=<%= volumes %>
-
-echo $VOLUMES > /home/testeandoLogs
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
@@ -31,7 +28,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      $VOLUMES \
+      <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -46,7 +43,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      $VOLUMES \
+      <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \
@@ -62,7 +59,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      $VOLUMES \
+      <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --link=$MAIL_NAME:mail \
@@ -76,7 +73,7 @@ else
       --publish=$PUBLISH_NETWORK:$PORT:80 \
       --volume=$BUNDLE_PATH:/bundle \
       --volume=/opt/backups:/backups \
-      $VOLUMES \
+      <%= volumes %> \
       --env-file=$ENV_FILE \
       --link=mongodb:mongodb \
       --hostname="$HOSTNAME-$APPNAME" \

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -13,8 +13,6 @@ DOCKERIMAGE=<%= dockerimage %>
 AFTER_RUN_COMMAND=<%= afterRunCommand %>
 VOLUMES=<%= volumes %>
 
-echo $VOLUMES
-
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
 


### PR DESCRIPTION
Cambios para habilitar el "bindeo" de volúmenes entre el host y el contenedor docker.

En el fichero `mup.json`, las distintas asociaciones de directorios se indicarán en un campo llamado `volumes`, que recibirá un array de cadenas, cada una siguiendo el formato que acepta la opción `--volume` del comando [`docker run`](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems).

Ejemplo:
```
...
"appName": "MiApp",
  "app": "..",
  "volumes": [
    "volumenEnHost:volumenEnContenedor",
    "/repositorio/datosBeta:/subidas"
  ],
  "env": {
   ...
  }
...
```